### PR TITLE
fix(install): compatibilité Debian 12 — libmagic1t64 et conflit dépôt Docker

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -504,9 +504,12 @@ translate_pkg_name() {
         esac
     else
         # Debian : normaliser libsodium* (glob invalide pour dpkg-query)
+        # et corriger les noms de paquets qui n'existent que sous Ubuntu ≥ 24.04
+        # (transition time_t 64 bits) mais pas sur Debian 12 (bookworm).
         case "$pkg" in
-            libsodium*) echo "libsodium-dev" ;;
-            *)          echo "$pkg" ;;
+            libsodium*)    echo "libsodium-dev" ;;
+            libmagic1t64)  echo "libmagic1" ;;
+            *)             echo "$pkg" ;;
         esac
     fi
 }

--- a/install/install.docker.sh
+++ b/install/install.docker.sh
@@ -7,6 +7,16 @@
 
 set -e
 
+# --- -1. IDEMPOTENCE : Docker déjà fonctionnel (ex: installé par OMV, une autre distro tool...) ---
+# Évite de désinstaller/recasser un Docker déjà en service (cf. incident OMV où ce script
+# a supprimé docker-ce géré par OpenMediaVault puis échoué à le réinstaller à cause d'un
+# conflit de clé GPG avec le dépôt Docker déjà déclaré par omvdocker.sources).
+if command -v docker >/dev/null 2>&1 && dpkg-query -W -f='${Status}' docker-ce 2>/dev/null | grep -q "ok installed"; then
+    echo -e "\033[0;32m✅ Docker est déjà installé et fonctionnel ($(docker --version)) — rien à faire.\033[0m"
+    echo -e "ℹ️  Pour forcer une réinstallation, désinstallez Docker manuellement puis relancez ce script."
+    exit 0
+fi
+
 # --- 0. DÉTECTION ARCH LINUX / STEAMOS ---
 if command -v pacman >/dev/null 2>&1; then
     echo -e "\033[0;36m--- Installation de Docker sur Arch Linux / SteamOS ---\033[0m"
@@ -60,16 +70,24 @@ echo -e "\033[0;36m--- Configuration du dépôt officiel Docker ---\033[0m"
 sudo apt-get update
 sudo apt-get install -y ca-certificates curl gnupg lsb-release
 
-sudo install -m 0755 -d /etc/apt/keyrings
-# Suppression de l'ancienne clé si elle existe
-sudo rm -f /etc/apt/keyrings/docker.gpg
-curl -fsSL https://download.docker.com/linux/$OS_TYPE/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-sudo chmod a+r /etc/apt/keyrings/docker.gpg
+# Un dépôt download.docker.com est peut-être déjà déclaré ailleurs (ex: omvdocker.sources
+# sur OpenMediaVault) avec sa propre clé Signed-By. En créer un second avec une clé
+# différente fait planter apt entier ("valeurs conflictuelles pour Signed-By").
+_EXISTING_DOCKER_SRC=$(grep -rl "download\.docker\.com" /etc/apt/sources.list.d/ /etc/apt/sources.list 2>/dev/null | grep -v '^/etc/apt/sources.list.d/docker.list$' || true)
+if [[ -n "$_EXISTING_DOCKER_SRC" ]]; then
+    echo -e "\033[0;33mℹ️  Dépôt Docker déjà déclaré par : $_EXISTING_DOCKER_SRC — réutilisation, pas de second dépôt créé.\033[0m"
+else
+    sudo install -m 0755 -d /etc/apt/keyrings
+    # Suppression de l'ancienne clé si elle existe
+    sudo rm -f /etc/apt/keyrings/docker.gpg
+    curl -fsSL https://download.docker.com/linux/$OS_TYPE/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+    sudo chmod a+r /etc/apt/keyrings/docker.gpg
 
-# Ajout du dépôt Docker officiel
-echo \
-  "deb [arch=$CURRENT_ARCH signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/$OS_TYPE \
-  $CODENAME stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+    # Ajout du dépôt Docker officiel
+    echo \
+      "deb [arch=$CURRENT_ARCH signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/$OS_TYPE \
+      $CODENAME stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+fi
 
 # --- 4. INSTALLATION ---
 echo -e "\033[0;36m--- Installation de Docker & Compose V2 ---\033[0m"

--- a/install/install_matterbridge.sh
+++ b/install/install_matterbridge.sh
@@ -42,13 +42,15 @@ URL="http://127.0.0.1:4243/webhook"
 # [telegram.mon_bot]
 # Token="TON_TOKEN_BOTFATHER_ICI"
 
-[gateway]
-[gateway.inout]
-[[gateway.inout.inout]]
+[[gateway]]
+name="inout"
+enable=true
+
+[[gateway.inout]]
 account="api.local"
 channel="api"
 
-# [[gateway.inout.inout]]
+# [[gateway.inout]]
 # account="telegram.mon_bot"
 # channel="-100123456789" # ID du groupe, ou laisser vide pour les DMs
 EOF


### PR DESCRIPTION
## Contexte

Rencontré lors d'une installation réelle sur Debian 12 (bookworm), sur une machine
faisant déjà tourner OpenMediaVault (OMV) avec Docker configuré via son propre plugin.

## Problèmes

1. **`libmagic1t64` n'existe pas sur Debian 12** — c'est un nom de paquet propre à
   Ubuntu ≥ 24.04 (transition time_t 64 bits). Comme la liste de paquets de
   `install.sh` est installée en un seul `apt-get install` groupé, la présence de ce
   nom invalide faisait échouer **toute la commande**, y compris `python3-venv` —
   bloquant ensuite la création du venv Python `~/.astro` avec une erreur peu
   parlante ("ensurepip is not available").

2. **`install/install.docker.sh` casse un Docker déjà géré par un autre outil** —
   le script désinstalle systématiquement `docker-ce` puis recrée son propre dépôt
   apt avec sa propre clé GPG (`/etc/apt/keyrings/docker.gpg`), sans vérifier qu'un
   dépôt Docker existe déjà (ex: `omvdocker.sources` sur OMV, `Signed-By:
   /usr/share/keyrings/docker.gpg`). Résultat : conflit "valeurs entrant en
   conflit... Signed-By", qui casse `apt` globalement pour le reste de
   l'installation, et laisse Docker désinstallé (daemon down, conteneurs arrêtés)
   jusqu'à réparation manuelle.

## Correctifs

- `translate_pkg_name()` (Debian) : `libmagic1t64` → `libmagic1` (paquet réel déjà
  fourni par `file` sur Debian, comme le fait déjà le mapping Arch existant).
- `install.docker.sh` :
  - sort immédiatement si `docker-ce` est déjà installé et fonctionnel (idempotence)
  - détecte un dépôt `download.docker.com` déjà déclaré ailleurs avant d'en créer un
    second, pour éviter le conflit de clé Signed-By

## Test

Reproduit et validé sur la machine concernée : `apt-get install` groupé passe sans
erreur, Docker réinstallé proprement sans perte de données/conteneurs.